### PR TITLE
Remove deprecated linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,8 +31,6 @@ linters-settings:
     disabled-checks:
       - dupImport
       - unnecessaryBlock
-  golint:
-    min-confidence: 0.7
   gofumpt:
     extra-rules: true
   gomnd:
@@ -88,7 +86,6 @@ linters:
     - gofmt
     - gofumpt
     - goimports
-    - golint
     - gomnd
     - gomodguard
     - goprintffuncname


### PR DESCRIPTION
Линтер golint на текущий момент в статусе archived
https://github.com/golang/lint
Поэтому предлагаю его убрать. 
Так же если пройтись линтером по проекту, то можно встретить вот такое замечание:
```bash
internal/service/repo/translation_postgres.go:35:44: mnd: Magic number: 64, in <argument> detected (gomnd)
        entities := make([]domain.Translation, 0, 64)
```