### PR TITLE
improve makefile. add help snippet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,59 +1,67 @@
 include .env.example
 export
 
-compose-up:
+# HELP =================================================================================================================
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+
+help: ## Display this help screen
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+compose-up: ### Run docker-compose
 	docker-compose up --build -d postgres rabbitmq && docker-compose logs -f
 .PHONY: compose-up
 
-compose-up-integration-test:
+compose-up-integration-test: ### Run docker-compose with integration test
 	docker-compose up --build --abort-on-container-exit --exit-code-from integration
 .PHONY: compose-up-integration-test
 
-compose-down:
+compose-down: ### Down docker-compose
 	docker-compose down --remove-orphans
 .PHONY: compose-down
 
-swag-v1:
+swag-v1: ### swag init
 	swag init -g internal/controller/http/v1/router.go
 .PHONY: swag-v1
 
-run: swag-v1
+run: swag-v1 ### swag run
 	go mod tidy && go mod download && \
 	DISABLE_SWAGGER_HTTP_HANDLER='' GIN_MODE=debug CGO_ENABLED=0 go run -tags migrate ./cmd/app
 .PHONY: run
 
-docker-rm-volume:
+docker-rm-volume: ### remove docker volume
 	docker volume rm go-clean-template_pg-data
 .PHONY: docker-rm-volume
 
-linter-golangci:
+linter-golangci: ### check by golangci linter
 	golangci-lint run
 .PHONY: linter-golangci
 
-linter-hadolint:
+linter-hadolint: ### check by hadolint linter
 	git ls-files --exclude='Dockerfile*' --ignored | xargs hadolint
 .PHONY: linter-hadolint
 
-linter-dotenv:
+linter-dotenv: ### check by dotenv linter
 	dotenv-linter
 .PHONY: linter-dotenv
 
-test:
+test: ### run test
 	go test -v -cover -race ./internal/...
 .PHONY: test
 
-integration-test:
+integration-test: ### run integration-test
 	go clean -testcache && go test -v ./integration-test/...
 .PHONY: integration-test
 
-mock:
+mock: ### run mockery
 	mockery --all -r --case snake
 .PHONY: mock
 
-migrate-create:
+migrate-create:  ### create new migration
 	migrate create -ext sql -dir migrations 'migrate_name'
 .PHONY: migrate-create
 
-migrate-up:
+migrate-up: ### migration up
 	migrate -path migrations -database '$(PG_URL)?sslmode=disable' up
 .PHONY: migrate-up


### PR DESCRIPTION
example:

```
$> make help

Usage:
  make <target>
  help             Display this help screen
  compose-up       Run docker-compose
  compose-up-integration-test  Run docker-compose with integration test
  compose-down     Down docker-compose
  run              swag run
  docker-rm-volume  remove docker volume
  linter-golangci  check by golangci linter
  linter-hadolint  check by hadolint linter
  linter-dotenv    check by dotenv linter
  test             run test
  integration-test  run integration-test
  mock             run mockery
  migrate-create   create new migration
  migrate-up       migration up
```