### PR TITLE
add lock for parallel tests

### DIFF
--- a/internal/usecase/translation_test.go
+++ b/internal/usecase/translation_test.go
@@ -67,12 +67,12 @@ func TestHistory(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
 			mu.Lock()
+			defer mu.Unlock()
+
 			tc.mock()
 
 			res, err := translation.History(context.Background())
-			mu.Unlock()
 
 			require.Equal(t, res, tc.res)
 			require.ErrorIs(t, err, tc.err)
@@ -121,12 +121,12 @@ func TestTranslate(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
 			mu.Lock()
+			defer mu.Unlock()
+
 			tc.mock()
 
 			res, err := translation.Translate(context.Background(), entity.Translation{})
-			mu.Unlock()
 
 			require.EqualValues(t, res, tc.res)
 			require.ErrorIs(t, err, tc.err)

--- a/internal/usecase/translation_test.go
+++ b/internal/usecase/translation_test.go
@@ -3,6 +3,7 @@ package usecase_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -40,6 +41,8 @@ func TestHistory(t *testing.T) {
 
 	translation, repo, _ := translation(t)
 
+	var mu sync.Mutex
+
 	tests := []test{
 		{
 			name: "empty result",
@@ -65,9 +68,11 @@ func TestHistory(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			mu.Lock()
 			tc.mock()
 
 			res, err := translation.History(context.Background())
+			mu.Unlock()
 
 			require.Equal(t, res, tc.res)
 			require.ErrorIs(t, err, tc.err)
@@ -79,6 +84,8 @@ func TestTranslate(t *testing.T) {
 	t.Parallel()
 
 	translation, repo, webAPI := translation(t)
+
+	var mu sync.Mutex
 
 	tests := []test{
 		{
@@ -115,9 +122,11 @@ func TestTranslate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			mu.Lock()
 			tc.mock()
 
 			res, err := translation.Translate(context.Background(), entity.Translation{})
+			mu.Unlock()
 
 			require.EqualValues(t, res, tc.res)
 			require.ErrorIs(t, err, tc.err)


### PR DESCRIPTION
Hi maintainers,

This is a really good template and I'm using it in my [project](https://github.com/yyq1025/balance-backend), but I find the test file here does not run tests in parallel correctly. Mock's EXPECTs are very likely to have a conflict when there are many (like 10) tests running concurrently. This issue could be easily reproduced by copying test cases 10 times and then running tests 10 times. You will be very likely to see there are 1 or 2 test cases that failed. Therefore, I add a lock here to avoid conflicts.

Thanks