### PR TITLE
fix: make swag-v1 cannot find router.go because of invalid path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ compose-down: ### Down docker compose
 .PHONY: compose-down
 
 swag-v1: ### swag init
-	swag init -g internal/controller/http/v1/router.go
+	swag init -g internal/controller/http/router.go
 .PHONY: swag-v1
 
 deps: ### deps tidy + verify


### PR DESCRIPTION
### Issue
The `make swag-v1` command is searching for `router.go` in:

```
internal/controller/http/v1/router.go
```

but the file is actually located in:

```
internal/controller/http/router.go
```

This causes the `swag` command to fail since it cannot find the file.

### Fix
- Updated the `Makefile` to point to the correct file.
- Adjusted the `swag` command to ensure it searches in the correct location.
- Verified that `swag` generates documentation properly.


### Related Files
- [`Makefile`](https://github.com/evrone/go-clean-template/blob/main/Makefile)  
- [`router.go`](https://github.com/evrone/go-clean-template/blob/main/internal/controller/http/router.go)  



### Testing
- Ran `make swag-v1` and confirmed that it successfully finds `router.go` and generates the expected Swagger documentation.
- Ensured no other commands were affected by this change.