### PR TITLE
Use .env in Makefile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ LOG_LEVEL=debug
 PG_POOL_MAX=2
 PG_URL=postgres://user:myAwEsOm3pa55@w0rd@localhost:5432/db
 # gRPC
-GRPC_PORT="8081"
+GRPC_PORT=8081
 # RMQ
 RMQ_RPC_SERVER=rpc_server
 RMQ_RPC_CLIENT=rpc_client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24
+      - name: Prepare environment file
+        run: cp .env.example .env
       - name: Unit Tests
         run: "make test"
       - name: Upload coverage report
@@ -77,5 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Prepare environment file
+        run: cp .env.example .env
       - name: Integration tests
         run: "make compose-up-integration-test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Modules caching
-FROM golang:1.24.2-alpine3.21 as modules
+FROM golang:1.24.3-alpine3.21 as modules
 
 COPY go.mod go.sum /modules/
 
@@ -8,7 +8,7 @@ WORKDIR /modules
 RUN go mod download
 
 # Step 2: Builder
-FROM golang:1.24.2-alpine3.21 as builder
+FROM golang:1.24.3-alpine3.21 as builder
 
 COPY --from=modules /go/pkg /go/pkg
 COPY . /app

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-include .env.example
+ifneq ($(wildcard .env),)
+include .env
 export
+else
+$(error .env file not found! Please create a .env in the project root before running make)
+endif
 
 LOCAL_BIN:=$(CURDIR)/bin
 BASE_STACK = docker compose -f docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ This template implements three types of servers:
 ### Local development
 
 ```sh
+# Create .env
+cp .env.example .env
 # Postgres, RabbitMQ
 make compose-up
 # Run app with migrations

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,6 +51,8 @@ golang服务的整洁架构模板
 本地开发
 
 ```sh
+# Create .env
+cp .env.example .env
 # Postgres, RabbitMQ
 make compose-up
 # Run app with migrations

--- a/README_RU.md
+++ b/README_RU.md
@@ -49,6 +49,8 @@
 ### Локальная разработка
 
 ```sh
+# Create .env
+cp .env.example .env
 # Postgres, RabbitMQ
 make compose-up
 # Запуск приложения и миграций

--- a/integration-test/Dockerfile
+++ b/integration-test/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Modules caching
-FROM golang:1.24.2-alpine3.21 as modules
+FROM golang:1.24.3-alpine3.21 as modules
 
 COPY go.mod go.sum /modules/
 
@@ -8,7 +8,7 @@ WORKDIR /modules
 RUN go mod download
 
 # Step 2: Tests
-FROM golang:1.24.2-alpine3.21
+FROM golang:1.24.3-alpine3.21
 
 COPY --from=modules /go/pkg /go/pkg
 COPY . /app


### PR DESCRIPTION
This PR introduces minor but important updates to env handling and dependencies:

* **Environment Configuration**:

  * Removed quotes from `GRPC_PORT` in `.env.example` for compatibility.
  * Updated the `Makefile` to include `.env` automatically and validate its presence.

* **Dockerfile**:

  * Upgraded base image from `golang:1.24.2-alpine3.21` to `1.24.3-alpine3.21` for both modules and builder stages.

* **Documentation**:

  * Updated `README.md` to include `.env` creation step in the local development setup instructions.
