### PR TITLE
Remove .env preparation steps from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24
-      - name: Prepare environment file
-        run: cp .env.example .env
       - name: Unit Tests
         run: "make test"
       - name: Upload coverage report
@@ -79,7 +77,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare environment file
-        run: cp .env.example .env
       - name: Integration tests
         run: "make compose-up-integration-test"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ ifneq ($(wildcard .env),)
 include .env
 export
 else
-$(error .env file not found! Please create a .env in the project root before running make)
+$(warning WARNING: .env file not found! Using .env.example)
+include .env.example
+export
 endif
 
 LOCAL_BIN:=$(CURDIR)/bin

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ This template implements three types of servers:
 ### Local development
 
 ```sh
-# Create .env
-cp .env.example .env
 # Postgres, RabbitMQ
 make compose-up
 # Run app with migrations

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,8 +51,6 @@ golang服务的整洁架构模板
 本地开发
 
 ```sh
-# Create .env
-cp .env.example .env
 # Postgres, RabbitMQ
 make compose-up
 # Run app with migrations

--- a/README_RU.md
+++ b/README_RU.md
@@ -49,8 +49,6 @@
 ### Локальная разработка
 
 ```sh
-# Create .env
-cp .env.example .env
 # Postgres, RabbitMQ
 make compose-up
 # Запуск приложения и миграций


### PR DESCRIPTION
This pull request simplifies the handling of environment files by removing the need to manually create a `.env` file from `.env.example`. It also updates documentation and CI workflows to reflect this change.

### Environment file handling updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL70-L71): Removed steps that manually copy `.env.example` to `.env` in CI workflows, as the `.env.example` file will now be used directly if `.env` is not present. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL70-L71) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL82-L83)
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L5-R7): Updated the `Makefile` to issue a warning instead of an error when `.env` is missing, and to automatically include `.env.example` as a fallback.

### Documentation updates:

* `README.md`, `README_CN.md`, `README_RU.md`: Removed instructions to manually create a `.env` file from `.env.example` during local development, as this step is no longer required. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-L58) [[2]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L54-L55) [[3]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L52-L53)