### PR TITLE
fix: overriding installation of postgres migrate tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ migrate-up: ### migration up
 
 bin-deps: ### install tools
 	go install tool
+	go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate
 .PHONY: bin-deps
 
 pre-commit: swag-v1 proto-v1 mock format linter-golangci test ### run pre-commit


### PR DESCRIPTION
if I track dependency versions in go.mod, then when I use go install to install the tools under that dependency, it will prioritize installing the version declared in go.mod. This means there's a different approach.
This means that the actual effect of tools.go file tracking + go run -mod=mod execution (https://github.com/golang/go/issues/25922#issuecomment-1065971260) is the same as that of go install and then executing it.
The key point is that you need to track versions in go.mod. (Both the go tool and tools.go can actually do this.)
Then we just need to use go tool to track the version as before, and then use go install to overwrite the special tool.

related issue: https://github.com/evrone/go-clean-template/issues/317