### PR TITLE
NATS: integration and Request-Reply pattern

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ GRPC_PORT=8081
 RMQ_RPC_SERVER=rpc_server
 RMQ_RPC_CLIENT=rpc_client
 RMQ_URL=amqp://guest:guest@localhost:5672/
+# NATS
+NATS_RPC_SERVER=rpc_server
+NATS_URL=nats://guest:guest@localhost:4222/
 # Metrics
 METRICS_ENABLED=true
 # Swagger

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ supported by [Evrone](https://evrone.com/?utm_source=github&utm_campaign=go-clea
 This template implements three types of servers:
 
 - AMQP RPC (based on RabbitMQ as [transport](https://github.com/rabbitmq/amqp091-go))
+- MQ RPC (based on NATS as [transport](https://github.com/nats-io/nats.go))
 - gRPC ([gRPC](https://grpc.io/) framework based on protobuf)
 - REST API ([Fiber](https://github.com/gofiber/fiber) framework)
 
@@ -54,7 +55,7 @@ This template implements three types of servers:
 ### Local development
 
 ```sh
-# Postgres, RabbitMQ
+# Postgres, RabbitMQ, NATS
 make compose-up
 # Run app with migrations
 make run
@@ -79,6 +80,9 @@ Check services:
   - URL: `amqp://guest:guest@127.0.0.1:5672/`
   - Client Exchange: `rpc_client`
   - Server Exchange: `rpc_server`
+- NATS RPC:
+  - URL: `nats://guest:guest@127.0.0.1:4222/`
+  - Server Exchange: `rpc_server`
 - REST API:
   - http://app.lvh.me/healthz | http://127.0.0.1:8080/healthz
   - http://app.lvh.me/metrics | http://127.0.0.1:8080/metrics
@@ -90,6 +94,9 @@ Check services:
   - `postgres://user:myAwEsOm3pa55@w0rd@127.0.0.1:5432/db`
 - RabbitMQ:
   - http://rabbitmq.lvh.me | http://127.0.0.1:15672
+  - Credentials: `guest` / `guest`
+- NATS monitoring:
+  - http://nats.lvh.me | http://127.0.0.1:8222/
   - Credentials: `guest` / `guest`
 
 ## Project structure

--- a/README_CN.md
+++ b/README_CN.md
@@ -36,6 +36,7 @@ golang服务的整洁架构模板
 此模板实现了三种类型的服务器：
 
 - AMQP RPC（基于 RabbitMQ 作为传输）
+- NATS RPC（基于 NATS 作为传输）
 - gRPC（基于 protobuf 的 [gRPC](https://grpc.io/) 框架）
 - REST API（基于 [Fiber](https://github.com/gofiber/fiber) 框架）
 
@@ -46,30 +47,12 @@ golang服务的整洁架构模板
 - [依赖注入](#依赖注入)
 - [整洁架构](#整洁架构)
 
-## 快速开始
-
-本地开发
-
-```sh
-# Postgres, RabbitMQ
-make compose-up
-# Run app with migrations
-make run
-```
-
-集成测试（可以在CI中运行）
-
-```sh
-# DB, app + migrations, integration tests
-make compose-up-integration-test
-```
-
 ## Quick start
 
 ### Local development
 
 ```sh
-# Postgres, RabbitMQ
+# Postgres, RabbitMQ, NATS
 make compose-up
 # Run app with migrations
 make run
@@ -94,6 +77,9 @@ Check services:
   - URL: `amqp://guest:guest@127.0.0.1:5672/`
   - Client Exchange: `rpc_client`
   - Server Exchange: `rpc_server`
+- NATS RPC:
+  - URL: `nats://guest:guest@127.0.0.1:4222/`
+  - Server Exchange: `rpc_server`
 - REST API:
   - http://app.lvh.me/healthz | http://127.0.0.1:8080/healthz
   - http://app.lvh.me/metrics | http://127.0.0.1:8080/metrics
@@ -105,6 +91,9 @@ Check services:
   - `postgres://user:myAwEsOm3pa55@w0rd@127.0.0.1:5432/db`
 - RabbitMQ:
   - http://rabbitmq.lvh.me | http://127.0.0.1:15672
+  - Credentials: `guest` / `guest`
+- NATS monitoring:
+  - http://nats.lvh.me | http://127.0.0.1:8222/
   - Credentials: `guest` / `guest`
 
 ## 工程架构

--- a/README_RU.md
+++ b/README_RU.md
@@ -34,6 +34,7 @@
 Этот шаблон поддерживает три типа серверов:
 
 - AMQP RPC (на основе RabbitMQ в качестве [транспорта](https://github.com/rabbitmq/amqp091-go))
+- NATS RPC (на основе NATS в качестве [транспорта](https://github.com/nats-io/nats.go))
 - gRPC ([gRPC](https://grpc.io/) фреймворк на основе protobuf)
 - REST API ([Fiber](https://github.com/gofiber/fiber) фреймворк)
 
@@ -49,7 +50,7 @@
 ### Локальная разработка
 
 ```sh
-# Postgres, RabbitMQ
+# Postgres, RabbitMQ, NATS
 make compose-up
 # Запуск приложения и миграций
 make run
@@ -74,6 +75,9 @@ make compose-up-all
   - URL: `amqp://guest:guest@127.0.0.1:5672/`
   - Client Exchange: `rpc_client`
   - Server Exchange: `rpc_server`
+- NATS RPC:
+  - URL: `nats://guest:guest@127.0.0.1:4222/`
+  - Server Exchange: `rpc_server`
 - REST API:
   - http://app.lvh.me/healthz | http://127.0.0.1:8080/healthz
   - http://app.lvh.me/metrics | http://127.0.0.1:8080/metrics
@@ -85,6 +89,9 @@ make compose-up-all
   - `postgres://user:myAwEsOm3pa55@w0rd@127.0.0.1:5432/db`
 - RabbitMQ:
   - http://rabbitmq.lvh.me | http://127.0.0.1:15672
+  - Credentials: `guest` / `guest`
+- NATS monitoring:
+  - http://nats.lvh.me | http://127.0.0.1:8222/
   - Credentials: `guest` / `guest`
 
 ## Структура проекта

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type (
 		PG      PG
 		GRPC    GRPC
 		RMQ     RMQ
+		NATS    NATS
 		Metrics Metrics
 		Swagger Swagger
 	}
@@ -52,6 +53,12 @@ type (
 		ServerExchange string `env:"RMQ_RPC_SERVER,required"`
 		ClientExchange string `env:"RMQ_RPC_CLIENT,required"`
 		URL            string `env:"RMQ_URL,required"`
+	}
+
+	// NATS -.
+	NATS struct {
+		ServerExchange string `env:"NATS_RPC_SERVER,required"`
+		URL            string `env:"NATS_URL,required"`
 	}
 
 	// Metrics -.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ x-backend-app-environment: &x-backend-app-environment
   RMQ_RPC_SERVER: "rpc_server"
   RMQ_RPC_CLIENT: "rpc_client"
   RMQ_URL: "amqp://guest:guest@rabbitmq:5672/"
+  # NATS
+  NATS_RPC_SERVER: "rpc_server"
+  NATS_URL: "nats://guest:guest@nats:4222/"
   # Metrics
   METRICS_ENABLED: "true"
   # Swagger
@@ -67,6 +70,20 @@ services:
       app_network:
         aliases:
           - rabbitmq.lvh.me
+
+  nats:
+    container_name: nats
+    image: nats:2.11-alpine
+    command: [ "-m", "8222", "-sd", "/nats-data", "-user", "guest", "-pass", "guest" ]
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    volumes:
+      - nats_data:/nats-data
+    networks:
+      app_network:
+        aliases:
+          - nats.lvh.me
 
   app:
     container_name: app
@@ -110,3 +127,4 @@ networks:
 volumes:
   db_data:
   rabbitmq_data:
+  nats_data:

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.6
+	github.com/nats-io/nats.go v1.46.1
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
@@ -289,6 +290,8 @@ require (
 	github.com/mutecomm/go-sqlcipher/v4 v4.4.0 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect
 	github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8 // indirect
+	github.com/nats-io/nkeys v0.4.11 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba // indirect
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1550,6 +1550,12 @@ github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8 h1:P48LjvUQpTReR3TQRbxSeSBsMXzfK0uol7eRcr7VBYQ=
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86wM1zFnC6/uDBfZGNwB65O+pR2OFi5q/YQaEUid1qA=
+github.com/nats-io/nats.go v1.46.1 h1:bqQ2ZcxVd2lpYI97xYASeRTY3I5boe/IVmuUDPitHfo=
+github.com/nats-io/nats.go v1.46.1/go.mod h1:iRWIPokVIFbVijxuMQq4y9ttaBTMe0SFdlZfMDd+33g=
+github.com/nats-io/nkeys v0.4.11 h1:q44qGV008kYd9W1b1nEBkNzvnWxtRSQ7A8BoqRrcfa0=
+github.com/nats-io/nkeys v0.4.11/go.mod h1:szDimtgmfOi9n25JpfIdGw12tZFYXqhGxjhVxsatHVE=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba h1:fhFP5RliM2HW/8XdcO5QngSfFli9GcRIpMXvypTQt6E=
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/internal/controller/nats_rpc/router.go
+++ b/internal/controller/nats_rpc/router.go
@@ -1,0 +1,19 @@
+package v1
+
+import (
+	v1 "github.com/evrone/go-clean-template/internal/controller/nats_rpc/v1"
+	"github.com/evrone/go-clean-template/internal/usecase"
+	"github.com/evrone/go-clean-template/pkg/logger"
+	"github.com/evrone/go-clean-template/pkg/nats/nats_rpc/server"
+)
+
+// NewRouter -.
+func NewRouter(t usecase.Translation, l logger.Interface) map[string]server.CallHandler {
+	routes := make(map[string]server.CallHandler)
+
+	{
+		v1.NewTranslationRoutes(routes, t, l)
+	}
+
+	return routes
+}

--- a/internal/controller/nats_rpc/v1/controller.go
+++ b/internal/controller/nats_rpc/v1/controller.go
@@ -1,0 +1,14 @@
+package v1
+
+import (
+	"github.com/evrone/go-clean-template/internal/usecase"
+	"github.com/evrone/go-clean-template/pkg/logger"
+	"github.com/go-playground/validator/v10"
+)
+
+// V1 -.
+type V1 struct {
+	t usecase.Translation
+	l logger.Interface
+	v *validator.Validate
+}

--- a/internal/controller/nats_rpc/v1/router.go
+++ b/internal/controller/nats_rpc/v1/router.go
@@ -1,0 +1,17 @@
+package v1
+
+import (
+	"github.com/evrone/go-clean-template/internal/usecase"
+	"github.com/evrone/go-clean-template/pkg/logger"
+	"github.com/evrone/go-clean-template/pkg/nats/nats_rpc/server"
+	"github.com/go-playground/validator/v10"
+)
+
+// NewTranslationRoutes -.
+func NewTranslationRoutes(routes map[string]server.CallHandler, t usecase.Translation, l logger.Interface) {
+	r := &V1{t: t, l: l, v: validator.New(validator.WithRequiredStructEnabled())}
+
+	{
+		routes["v1.getHistory"] = r.getHistory()
+	}
+}

--- a/internal/controller/nats_rpc/v1/translation.go
+++ b/internal/controller/nats_rpc/v1/translation.go
@@ -1,0 +1,22 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evrone/go-clean-template/pkg/nats/nats_rpc/server"
+	"github.com/nats-io/nats.go"
+)
+
+func (r *V1) getHistory() server.CallHandler {
+	return func(_ *nats.Msg) (interface{}, error) {
+		translationHistory, err := r.t.History(context.Background())
+		if err != nil {
+			r.l.Error(err, "amqp_rpc - V1 - getHistory")
+
+			return nil, fmt.Errorf("amqp_rpc - V1 - getHistory: %w", err)
+		}
+
+		return translationHistory, nil
+	}
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -21,6 +21,11 @@ http
         server rabbitmq:15672;
     }
 
+    upstream nats
+    {
+        server nats:8222;
+    }
+
     server
     {
         listen 80;
@@ -61,6 +66,22 @@ http
         location /
         {
             proxy_pass http://rabbitmq;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+    }
+
+    server
+    {
+        listen 80;
+        server_name nats.lvh.me;
+
+        location /
+        {
+            proxy_pass http://nats;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/pkg/nats/nats_rpc/client/client.go
+++ b/pkg/nats/nats_rpc/client/client.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	natsrpc "github.com/evrone/go-clean-template/pkg/nats/nats_rpc"
+	"github.com/goccy/go-json"
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	_defaultWaitTime = 5 * time.Second
+	_defaultAttempts = 10
+	_defaultTimeout  = 2 * time.Second
+)
+
+// Client -.
+type Client struct {
+	subject    string
+	connection *nats.Conn
+
+	timeout time.Duration
+}
+
+// New -.
+func New(
+	url string,
+	serverSubject string,
+	opts ...Option,
+) (*Client, error) {
+	connection, err := nats.Connect(
+		url,
+		nats.ReconnectWait(_defaultWaitTime),
+		nats.MaxReconnects(_defaultAttempts),
+		nats.Timeout(_defaultWaitTime),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("nats_rpc client - NewClient - nats.Connect: %w", err)
+	}
+
+	c := &Client{
+		subject:    serverSubject,
+		connection: connection,
+		timeout:    _defaultTimeout,
+	}
+
+	// Custom options
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	c.connection = connection
+
+	return c, nil
+}
+
+// Shutdown -.
+func (c *Client) Shutdown() error {
+	c.connection.Close()
+
+	return nil
+}
+
+// RemoteCall -.
+func (c *Client) RemoteCall(handler string, request, response interface{}) error {
+	var (
+		requestBody []byte
+		err         error
+	)
+
+	if request != nil {
+		requestBody, err = json.Marshal(request)
+		if err != nil {
+			return err
+		}
+	}
+
+	requestMessage := nats.Msg{
+		Subject: c.subject,
+		Header: nats.Header{
+			"Handler": []string{handler},
+		},
+		Data: requestBody,
+	}
+
+	message, err := c.connection.RequestMsg(&requestMessage, c.timeout)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return natsrpc.ErrTimeout
+	}
+
+	if err != nil {
+		return fmt.Errorf("nats_rpc client - Client - RemoteCall - c.connection.Conn.Request: %w", err)
+	}
+
+	switch message.Header.Get("Status") {
+	case natsrpc.Success:
+		err = json.Unmarshal(message.Data, &response)
+		if err != nil {
+			return fmt.Errorf("nats_rpc client - Client - RemoteCall - json.Unmarshal: %w", err)
+		}
+	case natsrpc.ErrBadHandler.Error():
+		return natsrpc.ErrBadHandler
+	case natsrpc.ErrInternalServer.Error():
+		return natsrpc.ErrInternalServer
+	}
+
+	return nil
+}

--- a/pkg/nats/nats_rpc/client/options.go
+++ b/pkg/nats/nats_rpc/client/options.go
@@ -1,0 +1,13 @@
+package client
+
+import "time"
+
+// Option -.
+type Option func(*Client)
+
+// Timeout -.
+func Timeout(timeout time.Duration) Option {
+	return func(c *Client) {
+		c.timeout = timeout
+	}
+}

--- a/pkg/nats/nats_rpc/errors.go
+++ b/pkg/nats/nats_rpc/errors.go
@@ -1,0 +1,15 @@
+package natsrpc
+
+import "errors"
+
+var (
+	// ErrTimeout -.
+	ErrTimeout = errors.New("timeout")
+	// ErrInternalServer -.
+	ErrInternalServer = errors.New("internal server error")
+	// ErrBadHandler -.
+	ErrBadHandler = errors.New("unregistered handler")
+)
+
+// Success -.
+const Success = "success"

--- a/pkg/nats/nats_rpc/server/options.go
+++ b/pkg/nats/nats_rpc/server/options.go
@@ -1,0 +1,13 @@
+package server
+
+import "time"
+
+// Option -.
+type Option func(*Server)
+
+// Timeout -.
+func Timeout(timeout time.Duration) Option {
+	return func(s *Server) {
+		s.timeout = timeout
+	}
+}

--- a/pkg/nats/nats_rpc/server/server.go
+++ b/pkg/nats/nats_rpc/server/server.go
@@ -1,0 +1,193 @@
+// Package server implements NATS RPC server.
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/evrone/go-clean-template/pkg/logger"
+	natsrpc "github.com/evrone/go-clean-template/pkg/nats/nats_rpc"
+	"github.com/goccy/go-json"
+	"github.com/nats-io/nats.go"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	_defaultWaitTime = 5 * time.Second
+	_defaultAttempts = 10
+	_defaultTimeout  = 2 * time.Second
+)
+
+// CallHandler -.
+type CallHandler func(*nats.Msg) (interface{}, error)
+
+// Server -.
+type Server struct {
+	ctx context.Context
+	eg  *errgroup.Group
+
+	subject      string
+	connection   *nats.Conn
+	subscription *nats.Subscription
+	router       map[string]CallHandler
+	stop         chan struct{}
+	notify       chan error
+
+	timeout time.Duration
+
+	logger logger.Interface
+}
+
+// New -.
+func New(
+	url,
+	serverSubject string,
+	router map[string]CallHandler,
+	l logger.Interface,
+	opts ...Option,
+) (*Server, error) {
+	group, ctx := errgroup.WithContext(context.Background())
+	group.SetLimit(1) // Run only one goroutine
+
+	connection, err := nats.Connect(
+		url,
+		nats.ReconnectWait(_defaultWaitTime),
+		nats.MaxReconnects(_defaultAttempts),
+		nats.Timeout(_defaultWaitTime),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("nats_rpc server - NewServer - nats.Connect: %w", err)
+	}
+
+	s := &Server{
+		ctx:        ctx,
+		eg:         group,
+		subject:    serverSubject,
+		connection: connection,
+		router:     router,
+		stop:       make(chan struct{}),
+		notify:     make(chan error, 1),
+		timeout:    _defaultTimeout,
+		logger:     l,
+	}
+
+	// Custom options
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s, nil
+}
+
+// Start -.
+func (s *Server) Start() {
+	s.eg.Go(func() error {
+		err := s.subscribe()
+		if err != nil {
+			s.notify <- err
+
+			close(s.notify)
+
+			return err
+		}
+
+		// Wait for stop signal
+		<-s.stop
+
+		return nil
+	})
+
+	s.logger.Info("nats_rpc server - Server - Started")
+}
+
+// Notify -.
+func (s *Server) Notify() <-chan error {
+	return s.notify
+}
+
+// Shutdown -.
+func (s *Server) Shutdown() error {
+	var shutdownErrors []error
+
+	close(s.stop)
+
+	// Wait for all goroutines to finish and get any error
+	err := s.eg.Wait()
+	if err != nil && !errors.Is(err, context.Canceled) {
+		s.logger.Error(err, "nats_rpc server - Server - Shutdown - s.eg.Wait")
+
+		shutdownErrors = append(shutdownErrors, err)
+	}
+
+	// Unsubscribe
+	if s.subscription != nil {
+		err := s.subscription.Unsubscribe()
+		if err != nil {
+			s.logger.Error(err, "nats_rpc server - Server - Shutdown - s.conn.Subscription.Unsubscribe")
+
+			shutdownErrors = append(shutdownErrors, err)
+		}
+	}
+
+	// Close connection
+	s.connection.Close()
+
+	s.logger.Info("nats_rpc server - Server - Shutdown")
+
+	return errors.Join(shutdownErrors...)
+}
+
+func (s *Server) subscribe() error {
+	subscription, err := s.connection.Subscribe(s.subject, s.handleMessage)
+	if err != nil {
+		return fmt.Errorf("nats_rpc server - subscribe - s.conn.AttemptConnect: %w", err)
+	}
+
+	s.subscription = subscription
+
+	return nil
+}
+
+func (s *Server) handleMessage(msg *nats.Msg) {
+	handler := msg.Header.Get("Handler")
+
+	callHandler, ok := s.router[handler]
+	if !ok {
+		s.publish(msg, nil, natsrpc.ErrBadHandler.Error())
+
+		return
+	}
+
+	response, err := callHandler(msg)
+	if err != nil {
+		s.publish(msg, nil, natsrpc.ErrInternalServer.Error())
+
+		s.logger.Error(err, "nats_rpc server - Server - handleMessage - callHandler")
+
+		return
+	}
+
+	body, err := json.Marshal(response)
+	if err != nil {
+		s.logger.Error(err, "nats_rpc server - Server - handleMessage - json.Marshal")
+
+		s.publish(msg, nil, natsrpc.ErrInternalServer.Error())
+
+		return
+	}
+
+	s.publish(msg, body, natsrpc.Success)
+}
+
+func (s *Server) publish(msg *nats.Msg, body []byte, status string) {
+	respondMsg := nats.NewMsg(msg.Reply)
+	respondMsg.Header.Set("Status", status)
+	respondMsg.Data = body
+
+	err := s.connection.PublishMsg(respondMsg)
+	if err != nil {
+		s.logger.Error(err, "nats_rpc server - Server - publish - msg.Respond")
+	}
+}

--- a/pkg/rabbitmq/rmq_rpc/client/client.go
+++ b/pkg/rabbitmq/rmq_rpc/client/client.go
@@ -138,20 +138,17 @@ func (c *Client) RemoteCall(handler string, request, response interface{}) error
 		return fmt.Errorf("rmq_rpc client - Client - RemoteCall - c.remoteCallWait: %w", err)
 	}
 
-	if call.status == rmqrpc.Success {
+	switch call.status {
+	case rmqrpc.Success:
 		err = json.Unmarshal(call.body, &response)
 		if err != nil {
 			return fmt.Errorf("rmq_rpc client - Client - RemoteCall - json.Unmarshal: %w", err)
 		}
 
 		return nil
-	}
-
-	if call.status == rmqrpc.ErrBadHandler.Error() {
+	case rmqrpc.ErrBadHandler.Error():
 		return rmqrpc.ErrBadHandler
-	}
-
-	if call.status == rmqrpc.ErrInternalServer.Error() {
+	case rmqrpc.ErrInternalServer.Error():
 		return rmqrpc.ErrInternalServer
 	}
 


### PR DESCRIPTION
This pull request adds support for NATS as an additional message queue transport alongside RabbitMQ. The changes include configuration updates, Docker integration, new server and client implementations for NATS RPC, and updates to documentation and integration tests to reflect the new functionality.

**NATS RPC Support**

* Added NATS configuration options to `config/config.go`, `.env.example`, and `docker-compose.yml`, including environment variables, service definition, and persistent volume. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R18) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R58-R63) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R35-R37) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R74-R87) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R130) [[6]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR18-R20)
* Updated dependencies to include NATS libraries (`nats.go`, `nkeys`, and `nuid`) in `go.mod`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R29) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R293-R294)

**Application and Controller Integration**

* Integrated NATS RPC server into the application lifecycle in `internal/app/app.go`, including startup, shutdown, and error handling. [[1]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R14-R27) [[2]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7L44-R58) [[3]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R69) [[4]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R86-R87) [[5]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R105-R109)
* Implemented NATS RPC controllers and routing in `internal/controller/nats_rpc/` and subdirectories, mirroring the structure of the existing RabbitMQ implementation. [[1]](diffhunk://#diff-64a3dfd04c19f0b6f8f60e4ad1db73d565e8d5a030d99a42ab1f0599150afeb1R1-R19) [[2]](diffhunk://#diff-2575c17811ccd033c8d3e9711ff7a162b67dd251c72884f336c3a500354e253bR1-R14) [[3]](diffhunk://#diff-8d18d43b99afe1ab7f21c446ed92c62f9e622b5934d93ba0b28c3becdf4949adR1-R17) [[4]](diffhunk://#diff-8dbee72b69d6deff5605b539deef59be227d00f6a11510b3f9e946d4239ef52eR1-R22)

**Testing and Documentation**

* Extended integration tests to cover NATS RPC client functionality in `integration-test/integration_test.go`. [[1]](diffhunk://#diff-53a888e9f3f932b65e64c3e283bbae5a43ae687eb2d105d8e742efbca28c522dL15-R16) [[2]](diffhunk://#diff-53a888e9f3f932b65e64c3e283bbae5a43ae687eb2d105d8e742efbca28c522dL37-R48) [[3]](diffhunk://#diff-53a888e9f3f932b65e64c3e283bbae5a43ae687eb2d105d8e742efbca28c522dL233-R291) [[4]](diffhunk://#diff-53a888e9f3f932b65e64c3e283bbae5a43ae687eb2d105d8e742efbca28c522dL260-R311)
* Updated documentation in `README.md`, `README_CN.md`, and `README_RU.md` to describe NATS RPC support, local development, service endpoints, and monitoring. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R58) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R85) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98-R100) [[5]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7R39) [[6]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L49-R55) [[7]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7R80-R82) [[8]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7R95-R97) [[9]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989R37) [[10]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L52-R53) [[11]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989R78-R80) [[12]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989R93-R95)

These changes make it possible to use either RabbitMQ or NATS as the transport for RPC communication in the application, improving flexibility and deployment options.