### PR TITLE
docs: update README and README_RU to include Request-Reply pattern for AMQP and NATS RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ supported by [Evrone](https://evrone.com/?utm_source=github&utm_campaign=go-clea
 
 This template implements three types of servers:
 
-- AMQP RPC (based on RabbitMQ as [transport](https://github.com/rabbitmq/amqp091-go))
-- MQ RPC (based on NATS as [transport](https://github.com/nats-io/nats.go))
+- AMQP RPC (based on RabbitMQ as [transport](https://github.com/rabbitmq/amqp091-go)
+  and [Request-Reply pattern](https://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html))
+- MQ RPC (based on NATS as [transport](https://github.com/nats-io/nats.go)
+  and [Request-Reply pattern](https://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html))
 - gRPC ([gRPC](https://grpc.io/) framework based on protobuf)
 - REST API ([Fiber](https://github.com/gofiber/fiber) framework)
 
@@ -108,9 +110,9 @@ Configuration and logger initialization. Then the main function "continues" in
 
 ### `config`
 
-The twelve-factor app stores config in environment variables (often shortened to `env vars` or `env`). Env vars are easy 
-to change between deploys without changing any code; unlike config files, there is little chance of them being checked 
-into the code repo accidentally; and unlike custom config files, or other config mechanisms such as Java System 
+The twelve-factor app stores config in environment variables (often shortened to `env vars` or `env`). Env vars are easy
+to change between deploys without changing any code; unlike config files, there is little chance of them being checked
+into the code repo accidentally; and unlike custom config files, or other config mechanisms such as Java System
 Properties, they are a language- and OS-agnostic standard.
 
 Config: [config.go](config/config.go)
@@ -192,7 +194,7 @@ routes := make(map[string]server.CallHandler)
 #### `internal/controller/grpc`
 
 Simple gRPC versioning.
-For v2, we will need to add the `grpc/v2` folder with the same content. 
+For v2, we will need to add the `grpc/v2` folder with the same content.
 Also add the `v2` folder to the proto files in `docs/proto`.
 And in the file `internal/controller/grpc/router.go` add the line:
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -33,8 +33,10 @@
 
 Этот шаблон поддерживает три типа серверов:
 
-- AMQP RPC (на основе RabbitMQ в качестве [транспорта](https://github.com/rabbitmq/amqp091-go))
-- NATS RPC (на основе NATS в качестве [транспорта](https://github.com/nats-io/nats.go))
+- AMQP RPC (на основе RabbitMQ в качестве [транспорта](https://github.com/rabbitmq/amqp091-go)
+  и [Request-Reply паттерна]((https://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html)))
+- NATS RPC (на основе NATS в качестве [транспорта](https://github.com/nats-io/nats.go)
+  и [Request-Reply паттерна]((https://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html))))
 - gRPC ([gRPC](https://grpc.io/) фреймворк на основе protobuf)
 - REST API ([Fiber](https://github.com/gofiber/fiber) фреймворк)
 
@@ -331,8 +333,8 @@ func (uc *UseCase) Do() {
 
 **Внешний слой** имеет ограничения:
 
-- Компоненты этого слоя не могут знать друг о друге и взаимодействовать напрямую. Обращение друг к другу происходит через
-  внутренний слой - слой бизнес-логики.
+- Компоненты этого слоя не могут знать друг о друге и взаимодействовать напрямую. Обращение друг к другу происходит
+  через внутренний слой - слой бизнес-логики.
 - Вызовы во внутренний слой выполняются через интерфейсы (!).
 - Данные передаются в формате, удобном для бизнес-логики (структуры хранятся в `internal/entity`).
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the use of the Request-Reply pattern in the AMQP and NATS RPC server implementations, and makes minor improvements to the Russian documentation for readability.

Documentation updates:

* Added explicit mention of the [Request-Reply pattern](https://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html) for both AMQP and NATS RPC servers in `README.md`.
* Updated the Russian documentation (`README_RU.md`) to include references to the Request-Reply pattern for AMQP and NATS RPC servers, with links to the relevant pattern description.

Minor improvements:

* Improved line wrapping for better readability in the Russian documentation, clarifying that outer layer components interact only via the inner business logic layer.