### PR TITLE
feat: add resource limits and reservations for service in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,12 +99,21 @@ services:
     depends_on:
       - db
       - rabbitmq
+    deploy:
+      resources:
+        limits:
+          cpus: '1.00'
+          memory: '2Gb'
+        reservations:
+          cpus: '0.60'
+          memory: '1Gb'
     networks:
       app_network:
         aliases:
           - app.lvh.me
 
   nginx:
+    container_name: nginx
     image: nginx:1.29.2-alpine
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf


### PR DESCRIPTION
This pull request adds resource constraints to the service configuration in `docker-compose.yml`. The main change is the introduction of CPU and memory limits and reservations for the service, which helps ensure more predictable resource usage and stability when running in a containerized environment.

Resource management improvements:

* Added `deploy.resources.limits` and `deploy.resources.reservations` to the service definition in `docker-compose.yml`, setting CPU and memory limits (1 CPU, 2GB memory) and reservations (0.6 CPU, 1GB memory) to control resource allocation.