### PR TITLE
feat: update README to reflect addition of NATS RPC and enhance domain descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Using the principles of Robert Martin (aka Uncle Bob).
 [Go-clean-template](https://evrone.com/go-clean-template?utm_source=github&utm_campaign=go-clean-template) is created &
 supported by [Evrone](https://evrone.com/?utm_source=github&utm_campaign=go-clean-template).
 
-This template implements three types of servers:
+This template implements four types of servers:
 
 - AMQP RPC (based on RabbitMQ as [transport](https://github.com/rabbitmq/amqp091-go)
   and [Request-Reply pattern](https://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html))
@@ -55,10 +55,55 @@ All domains are available across all four transports (REST, gRPC, AMQP RPC, NATS
 
 ## Content
 
+- [Domains](#domains)
 - [Quick start](#quick-start)
 - [Project structure](#project-structure)
 - [Dependency Injection](#dependency-injection)
 - [Clean Architecture](#clean-architecture)
+
+## Domains
+
+The template includes three fully implemented domains, each available across all four transports (REST, gRPC, AMQP RPC, NATS RPC).
+
+### User Authentication
+
+Registration, login, and JWT-based authorization.
+
+| Operation   | REST                     | gRPC                     |
+|-------------|--------------------------|--------------------------|
+| Register    | `POST /v1/auth/register` | `AuthService/Register`   |
+| Login       | `POST /v1/auth/login`    | `AuthService/Login`      |
+| Get profile | `GET /v1/user/profile`   | `AuthService/GetProfile` |
+
+- Passwords hashed with bcrypt
+- JWT tokens with configurable expiry
+- Auth middleware on all transports
+
+### Task Management
+
+CRUD operations with a status state machine.
+
+| Operation  | REST                         | gRPC                         |
+|------------|------------------------------|------------------------------|
+| Create     | `POST /v1/tasks`             | `TaskService/CreateTask`     |
+| List       | `GET /v1/tasks`              | `TaskService/ListTasks`      |
+| Get        | `GET /v1/tasks/:id`          | `TaskService/GetTask`        |
+| Update     | `PUT /v1/tasks/:id`          | `TaskService/UpdateTask`     |
+| Transition | `PATCH /v1/tasks/:id/status` | `TaskService/TransitionTask` |
+| Delete     | `DELETE /v1/tasks/:id`       | `TaskService/DeleteTask`     |
+
+- Status transitions: `todo` → `in_progress` → `done` (and `in_progress` → `todo`)
+- Pagination with `limit`/`offset` and optional status filter
+- Tasks scoped to the authenticated user
+
+### Translation
+
+Text translation via external API with history tracking.
+
+| Operation | REST                                | gRPC                                    |
+|-----------|-------------------------------------|-----------------------------------------|
+| Translate | `POST /v1/translation/do-translate` | `TranslationHistoryService/DoTranslate` |
+| History   | `GET /v1/translation/history`       | `TranslationHistoryService/ShowHistory` |
 
 ## Quick start
 
@@ -171,9 +216,10 @@ go run -tags migrate ./cmd/app
 
 ### `internal/controller`
 
-Server handler layer (MVC controllers). The template shows 3 servers:
+Server handler layer (MVC controllers). The template shows 4 servers:
 
 - AMQP RPC (based on RabbitMQ as transport)
+- NATS RPC (based on NATS as transport)
 - gRPC ([gRPC](https://grpc.io/) framework based on protobuf)
 - REST API ([Fiber](https://github.com/gofiber/fiber) framework)
 
@@ -193,7 +239,7 @@ And in the file `internal/controller/amqp_rpc/router.go` add the line:
 routes := make(map[string]server.CallHandler)
 
 {
-    v1.NewTranslationRoutes(routes, t, l)
+    v1.NewRoutes(routes, t, u, tk, j, l)
 }
 
 {
@@ -210,10 +256,14 @@ And in the file `internal/controller/grpc/router.go` add the line:
 
 ```go
 {
+    v1.NewAuthRoutes(app, u, l)
+    v1.NewTaskRoutes(app, tk, l)
     v1.NewTranslationRoutes(app, t, l)
 }
 
 {
+    v2.NewAuthRoutes(app, u, l)
+    v2.NewTaskRoutes(app, tk, l)
     v2.NewTranslationRoutes(app, t, l)
 }
 
@@ -230,7 +280,7 @@ And in the file `internal/controller/nats_rpc/router.go` add the line:
 routes := make(map[string]server.CallHandler)
 
 {
-    v1.NewTranslationRoutes(routes, t, l)
+    v1.NewRoutes(routes, t, u, tk, j, l)
 }
 
 {
@@ -247,11 +297,11 @@ And in the file `internal/controller/restapi/router.go` add the line:
 ```go
 apiV1Group := app.Group("/v1")
 {
-	v1.NewTranslationRoutes(apiV1Group, t, l)
+	v1.NewRoutes(apiV1Group, t, u, tk, jwtManager, l)
 }
 apiV2Group := app.Group("/v2")
 {
-	v2.NewTranslationRoutes(apiV2Group, t, l)
+	v2.NewRoutes(apiV2Group, t, u, tk, jwtManager, l)
 }
 ```
 
@@ -328,7 +378,7 @@ func (uc *UseCase) Do() {
 }
 ```
 
-It will also allow us to do auto-generation of mocks (for example with [mockery](https://github.com/vektra/mockery)) and
+It will also allow us to do auto-generation of mocks (for example with [go.uber.org/mock](https://go.uber.org/mock)) and
 easily write unit tests.
 
 > We are not tied to specific implementations in order to always be able to change one component to another.
@@ -414,9 +464,9 @@ Or more complex business logic:
 - **Use Cases** is business logic located in `internal/usecase`.
 
 The layer with which business logic directly interacts is usually called the _infrastructure_ layer.
-These can be repositories `internal/usecase/repo`, external webapi `internal/usecase/webapi`, any pkg, and other
+These can be repositories `internal/repo/persistent`, external webapi `internal/repo/webapi`, any pkg, and other
 microservices.
-In the template, the _infrastructure_ packages are located inside `internal/usecase`.
+In the template, the _infrastructure_ packages are located inside `internal/repo`.
 
 You can choose how to call the entry points as you wish. The options are:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -33,7 +33,7 @@ golang服务的整洁架构模板
 [Go 整洁模板](https://evrone.com/go-clean-template?utm_source=github&utm_campaign=go-clean-template) 由
 [Evrone](https://evrone.com/?utm_source=github&utm_campaign=go-clean-template) 创建和提供支持.
 
-此模板实现了三种类型的服务器：
+此模板实现了四种类型的服务器：
 
 - AMQP RPC（基于 RabbitMQ 作为传输）
 - NATS RPC（基于 NATS 作为传输）
@@ -50,10 +50,55 @@ golang服务的整洁架构模板
 
 ## 内容
 
+- [领域](#领域)
 - [快速开始](#快速开始)
 - [工程架构](#工程架构)
 - [依赖注入](#依赖注入)
 - [整洁架构](#整洁架构)
+
+## 领域
+
+模板包含三个完整实现的领域，每个领域均可通过所有四种传输协议（REST、gRPC、AMQP RPC、NATS RPC）访问。
+
+### 用户认证
+
+注册、登录和基于 JWT 的授权。
+
+| 操作   | REST                     | gRPC                     |
+|------|--------------------------|--------------------------|
+| 注册   | `POST /v1/auth/register` | `AuthService/Register`   |
+| 登录   | `POST /v1/auth/login`    | `AuthService/Login`      |
+| 获取资料 | `GET /v1/user/profile`   | `AuthService/GetProfile` |
+
+- 密码使用 bcrypt 加密
+- JWT 令牌支持可配置的过期时间
+- 所有传输协议均有认证中间件
+
+### 任务管理
+
+CRUD 操作，支持状态状态机。
+
+| 操作   | REST                         | gRPC                         |
+|------|------------------------------|------------------------------|
+| 创建   | `POST /v1/tasks`             | `TaskService/CreateTask`     |
+| 列表   | `GET /v1/tasks`              | `TaskService/ListTasks`      |
+| 获取   | `GET /v1/tasks/:id`          | `TaskService/GetTask`        |
+| 更新   | `PUT /v1/tasks/:id`          | `TaskService/UpdateTask`     |
+| 状态转换 | `PATCH /v1/tasks/:id/status` | `TaskService/TransitionTask` |
+| 删除   | `DELETE /v1/tasks/:id`       | `TaskService/DeleteTask`     |
+
+- 状态转换：`todo` → `in_progress` → `done`（以及 `in_progress` → `todo`）
+- 支持 `limit`/`offset` 分页和可选状态过滤
+- 任务绑定到已认证的用户
+
+### 翻译
+
+通过外部 API 进行文本翻译，支持历史记录。
+
+| 操作 | REST                                | gRPC                                    |
+|----|-------------------------------------|-----------------------------------------|
+| 翻译 | `POST /v1/translation/do-translate` | `TranslationHistoryService/DoTranslate` |
+| 历史 | `GET /v1/translation/history`       | `TranslationHistoryService/ShowHistory` |
 
 ## Quick start
 
@@ -162,9 +207,10 @@ go run -tags migrate ./cmd/app
 
 ### `internal/controller`
 
-服务器处理层（MVC 控制器）。模板展示了 3 种服务器：
+服务器处理层（MVC 控制器）。模板展示了 4 种服务器：
 
 - AMQP RPC（基于 RabbitMQ 作为传输）
+- NATS RPC（基于 NATS 作为传输）
 - gRPC（基于 protobuf 的 [gRPC](https://grpc.io/) 框架）
 - REST API（基于 [Fiber](https://github.com/gofiber/fiber) 框架）
 
@@ -184,7 +230,7 @@ go run -tags migrate ./cmd/app
 routes := make(map[string]server.CallHandler)
 
 {
-    v1.NewTranslationRoutes(routes, t, l)
+    v1.NewRoutes(routes, t, u, tk, j, l)
 }
 
 {
@@ -201,10 +247,14 @@ routes := make(map[string]server.CallHandler)
 
 ```go
 {
+    v1.NewAuthRoutes(app, u, l)
+    v1.NewTaskRoutes(app, tk, l)
     v1.NewTranslationRoutes(app, t, l)
 }
 
 {
+    v2.NewAuthRoutes(app, u, l)
+    v2.NewTaskRoutes(app, tk, l)
     v2.NewTranslationRoutes(app, t, l)
 }
 
@@ -221,7 +271,7 @@ reflection.Register(app)
 routes := make(map[string]server.CallHandler)
 
 {
-    v1.NewTranslationRoutes(routes, t, l)
+    v1.NewRoutes(routes, t, u, tk, j, l)
 }
 
 {
@@ -238,11 +288,11 @@ routes := make(map[string]server.CallHandler)
 ```go
 apiV1Group := app.Group("/v1")
 {
-	v1.NewTranslationRoutes(apiV1Group, t, l)
+	v1.NewRoutes(apiV1Group, t, u, tk, jwtManager, l)
 }
 apiV2Group := app.Group("/v2")
 {
-	v2.NewTranslationRoutes(apiV2Group, t, l)
+	v2.NewRoutes(apiV2Group, t, u, tk, jwtManager, l)
 }
 ```
 
@@ -289,7 +339,7 @@ RabbitMQ RPC 模式：
 这使得业务逻辑独立（且可移植）
 我们可以覆盖接口的实现，而无需更改 `usecase` 包.
 
-它还将允许我们自动生成相关mock（例如使用 [mockery](https://github.com/vektra/mockery)），以便进行单元测试.
+它还将允许我们自动生成相关mock（例如使用 [go.uber.org/mock](https://go.uber.org/mock)），以便进行单元测试.
 > 我们不依赖于特定的实现，以便始终能够将一个组件更改为另一个组件
 > 如果新组件实现了接口，则业务逻辑无需更改。
 
@@ -395,8 +445,8 @@ HTTP 和数据库都在外层，这意味着他们彼此无法感知
 
 - **Use Cases** 业务逻辑位于 `internal/usecase` 中
   与业务逻辑直接交互的层通常称为_infrastructure_ 层
-  这些可以是存储库 `internal/usecase/repo`、外部 webapi `internal/usecase/webapi`、任何包和其他微服务。
-  在模板中，_infrastructure_ 包位于 `internal/usecase` 中
+  这些可以是存储库 `internal/repo/persistent`、外部 webapi `internal/repo/webapi`、任何包和其他微服务。
+  在模板中，_infrastructure_ 包位于 `internal/repo` 中
 
 您可以根据需要决定你要调用的入口点，包括：
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -31,7 +31,7 @@
 [Go-clean-template](https://evrone.com/go-clean-template?utm_source=github&utm_campaign=go-clean-template) создан и
 поддерживается [Evrone](https://evrone.com/?utm_source=github&utm_campaign=go-clean-template).
 
-Этот шаблон поддерживает три типа серверов:
+Этот шаблон поддерживает четыре типа серверов:
 
 - AMQP RPC (на основе RabbitMQ в качестве [транспорта](https://github.com/rabbitmq/amqp091-go)
   и [Request-Reply паттерна]((https://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html)))
@@ -50,10 +50,55 @@
 
 ## Содержание
 
+- [Домены](#домены)
 - [Быстрый старт](#быстрый-старт)
 - [Структура проекта](#структура-проекта)
 - [Внедрение зависимостей](#внедрение-зависимостей)
 - [Чистая Архитектура](#чистая-архитектура)
+
+## Домены
+
+Шаблон включает три полностью реализованных домена, каждый из которых доступен через все четыре транспорта (REST, gRPC, AMQP RPC, NATS RPC).
+
+### Аутентификация пользователей
+
+Регистрация, вход и авторизация на основе JWT.
+
+| Операция    | REST                     | gRPC                     |
+|-------------|--------------------------|--------------------------|
+| Регистрация | `POST /v1/auth/register` | `AuthService/Register`   |
+| Вход        | `POST /v1/auth/login`    | `AuthService/Login`      |
+| Профиль     | `GET /v1/user/profile`   | `AuthService/GetProfile` |
+
+- Пароли хешируются с помощью bcrypt
+- JWT-токены с настраиваемым временем жизни
+- Middleware авторизации на всех транспортах
+
+### Управление задачами
+
+CRUD-операции со стейт-машиной статусов.
+
+| Операция      | REST                         | gRPC                         |
+|---------------|------------------------------|------------------------------|
+| Создание      | `POST /v1/tasks`             | `TaskService/CreateTask`     |
+| Список        | `GET /v1/tasks`              | `TaskService/ListTasks`      |
+| Получение     | `GET /v1/tasks/:id`          | `TaskService/GetTask`        |
+| Обновление    | `PUT /v1/tasks/:id`          | `TaskService/UpdateTask`     |
+| Смена статуса | `PATCH /v1/tasks/:id/status` | `TaskService/TransitionTask` |
+| Удаление      | `DELETE /v1/tasks/:id`       | `TaskService/DeleteTask`     |
+
+- Переходы статусов: `todo` → `in_progress` → `done` (и `in_progress` → `todo`)
+- Пагинация с `limit`/`offset` и опциональная фильтрация по статусу
+- Задачи привязаны к аутентифицированному пользователю
+
+### Перевод
+
+Перевод текста через внешний API с сохранением истории.
+
+| Операция | REST                                | gRPC                                    |
+|----------|-------------------------------------|-----------------------------------------|
+| Перевод  | `POST /v1/translation/do-translate` | `TranslationHistoryService/DoTranslate` |
+| История  | `GET /v1/translation/history`       | `TranslationHistoryService/ShowHistory` |
 
 ## Быстрый старт
 
@@ -166,9 +211,10 @@ go run -tags migrate ./cmd/app
 
 ### `internal/controller`
 
-Слой хэндлеров сервера (MVC контроллеры). В шаблоне показана работа 3 серверов:
+Слой хэндлеров сервера (MVC контроллеры). В шаблоне показана работа 4 серверов:
 
 - AMQP RPC (на основе RabbitMQ в качестве транспорта)
+- NATS RPC (на основе NATS в качестве транспорта)
 - gRPC ([gRPC](https://grpc.io/) фреймворк на основе protobuf)
 - REST API ([Fiber](https://github.com/gofiber/fiber) фреймворк)
 
@@ -188,7 +234,7 @@ go run -tags migrate ./cmd/app
 routes := make(map[string]server.CallHandler)
 
 {
-    v1.NewTranslationRoutes(routes, t, l)
+    v1.NewRoutes(routes, t, u, tk, j, l)
 }
 
 {
@@ -205,10 +251,14 @@ routes := make(map[string]server.CallHandler)
 
 ```go
 {
+    v1.NewAuthRoutes(app, u, l)
+    v1.NewTaskRoutes(app, tk, l)
     v1.NewTranslationRoutes(app, t, l)
 }
 
 {
+    v2.NewAuthRoutes(app, u, l)
+    v2.NewTaskRoutes(app, tk, l)
     v2.NewTranslationRoutes(app, t, l)
 }
 
@@ -225,7 +275,7 @@ reflection.Register(app)
 routes := make(map[string]server.CallHandler)
 
 {
-    v1.NewTranslationRoutes(routes, t, l)
+    v1.NewRoutes(routes, t, u, tk, j, l)
 }
 
 {
@@ -242,11 +292,11 @@ routes := make(map[string]server.CallHandler)
 ```go
 apiV1Group := app.Group("/v1")
 {
-    v1.NewTranslationRoutes(apiV1Group, t, l)
+	v1.NewRoutes(apiV1Group, t, u, tk, jwtManager, l)
 }
 apiV2Group := app.Group("/v2")
 {
-	v2.NewTranslationRoutes(apiV2Group, t, l)
+	v2.NewRoutes(apiV2Group, t, u, tk, jwtManager, l)
 }
 ```
 
@@ -324,7 +374,7 @@ func (uc *UseCase) Do() {
 ```
 
 Благодаря разделению через интерфейсы можно генерировать моки (например,
-используя [mockery](https://github.com/vektra/mockery)) и легко писать юнит-тесты.
+используя [go.uber.org/mock](https://go.uber.org/mock)) и легко писать юнит-тесты.
 
 > Мы не привязаны к конкретным реализациям и всегда можем заменить один компонент на другой.
 > Если новый компонент реализует интерфейс, то в бизнес-логике ничего не нужно менять.
@@ -409,9 +459,9 @@ func (uc *UseCase) Do() {
 - **Use Cases** - это бизнес-логика. Располагается в папке `internal/usecase`.
 
 Слой, с которым бизнес-логика взаимодействует напрямую, обычно называется _инфраструктурным_ слоем.
-Это может быть репозиторий `internal/usecase/repo`, внешнее webapi `internal/usecase/webapi`, любой пакет или
+Это может быть репозиторий `internal/repo/persistent`, внешнее webapi `internal/repo/webapi`, любой пакет или
 микросервис.
-В шаблоне пакеты _infrastructure_ размещены внутри `internal/usecase`.
+В шаблоне пакеты _infrastructure_ размещены внутри `internal/repo`.
 
 Вы можете выбирать, как называть точки входа, по своему усмотрению. Варианты такие:
 


### PR DESCRIPTION
This pull request updates the documentation in all three main language variants (`README.md`, `README_CN.md`, and `README_RU.md`) to clarify and expand on the available server types and supported domains in the Go Clean Template project. It also improves the accuracy of the architecture explanations and updates example code to match the current API. The changes ensure consistency across the English, Chinese, and Russian documentation.

**Key documentation improvements:**

*Server types and supported domains:*
- Updated all READMEs to state that the template implements four server types (REST, gRPC, AMQP RPC, NATS RPC), instead of three. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[2]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L36-R36) [[3]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L34-R34)
- Added detailed sections describing the three fully implemented domains (User Authentication, Task Management, Translation) and their availability across all four transports, with operation tables and feature lists. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R107) [[2]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7R53-R102) [[3]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989R53-R102)

*Example code and usage updates:*
- Updated example router code snippets to use unified `v1.NewRoutes` and `v2.NewRoutes` functions, reflecting the current API and reducing boilerplate in all controller types (REST, gRPC, AMQP RPC, NATS RPC). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L196-R242) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R259-R266) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L233-R283) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L250-R304) [[5]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L187-R233) [[6]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7R250-R257) [[7]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L224-R274) [[8]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L241-R295) [[9]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L191-R237) [[10]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989R254-R261) [[11]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L228-R278) [[12]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L245-R299)

*Architecture and terminology corrections:*
- Clarified the location and naming of infrastructure packages, changing references from `internal/usecase/repo` and `internal/usecase/webapi` to `internal/repo/persistent` and `internal/repo/webapi`, and updated the explanation of the infrastructure layer accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L417-R469) [[2]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L398-R449) [[3]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L412-R464)
- Updated the recommended mocking tool from `mockery` to `go.uber.org/mock` for auto-generating mocks in all language variants. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L331-R381) [[2]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L292-R342) [[3]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L327-R377)

These changes bring the documentation up to date with the current codebase, improve clarity for new users, and ensure consistency across all supported languages.