### PR TITLE
chore(ci): update linting actions to use fail_level for error reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: reviewdog/action-yamllint@v1
         with:
-          fail_on_error: true
+          fail_level: error
           reporter: github-pr-review
           yamllint_flags: '-d "{extends: default, rules: {truthy: disable}}" .'
 
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: reviewdog/action-hadolint@v1
         with:
-          fail_on_error: true
+          fail_level: error
           reporter: github-pr-review
 
   dotenv-linter:


### PR DESCRIPTION
This pull request makes minor updates to the CI workflow configuration, specifically changing how failure levels are specified for certain linting actions. These changes improve consistency and clarity in the workflow settings.

- **CI Workflow Configuration Updates:**
  * Changed the `reviewdog/action-yamllint` and `reviewdog/action-hadolint` actions in `.github/workflows/ci.yml` to use `fail_level: error` instead of `fail_on_error: true` for specifying error handling behavior. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL27-R27) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL38-R38)